### PR TITLE
CCP-1627: added support for displayOn being an array of product ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
  All notable changes to this project will be documented in this file.
  The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-##[1.1.1] - 2019-07-17
+## [1.2.0] - 2019-07-26
+### Added
+-  support for array of product ids in displayOn config field
+
+## [1.1.1] - 2019-07-17
 ### Fixed
 -  checkout button state updating in checkbox component
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the Terms and conditions extension to your Shopgate Connect deployment confi
 
 Set the following values in your Shopgate Connect Admin:
 * checkboxValues - (array of Objects) contains specific product terms and conditions information.
-    * displayOn - (string) triggering product Id or all proudcts (triggering string to list for all products)
+    * displayOn - (string|string[]) triggering product Id or all products or array of triggering product ids (triggering string to list for all products)
     * productCheckboxValues - (array of Objects) used to hold terms and conditions values for specific products.
         * text - (string) text for terms and conditions checkbox.
         * textColor - (string) hex value for text color of terms and conditions text.
@@ -51,6 +51,15 @@ If the value checkBoxValues is left empty, checkout will be allowed and no check
       "productCheckboxValues": [
         {
           "text": "002 text",
+          "textColor": "#741416"
+        }
+      ]
+    },
+    {
+      "displayOn": ["003", "004". "005"],
+      "productCheckboxValues": [
+        {
+          "text": "003 004 and 005 text",
           "textColor": "#741416"
         }
       ]

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.2.0-rc.1",
   "id": "@shopgate/terms-and-conditions",
   "components": [
     {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0-rc.1",
+  "version": "1.2.0",
   "id": "@shopgate/terms-and-conditions",
   "components": [
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/terms-and-conditions",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Frontend Extension which displays Terms and Conditions on the Cart Page",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -60,8 +60,12 @@ export const getTermsToDisplay = createSelector(
     if (!productIds) {
       return null;
     }
-    return checkboxValues.filter((value =>
-      productIds.includes(value.displayOn) || value.displayOn === ALL_PRODUCTS));
+    return checkboxValues.filter((value) => {
+      if (Array.isArray(value.displayOn)) {
+        return !!productIds.find(id => value.displayOn.includes(id));
+      }
+      return productIds.includes(value.displayOn) || value.displayOn === ALL_PRODUCTS;
+    });
   }
 );
 


### PR DESCRIPTION
# Pull Request Template

## Description

The change made allows onDisplay property of checkbox configuration object to be an array of product ids.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
